### PR TITLE
Set automountServiceAccountToken to true for deployment

### DIFF
--- a/deploy-example/kubernetes-manifest/2_deployment.yaml
+++ b/deploy-example/kubernetes-manifest/2_deployment.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         name: imagepullsecret-patcher
     spec:
+      automountServiceAccountToken: true
       serviceAccountName: imagepullsecret-patcher
       containers:
         - name: imagepullsecret-patcher


### PR DESCRIPTION
Fixes #8 by setting the `automountServiceAccountToken` for the example