### PR TITLE
feat: implement configurable loop duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ To install imagepullsecret-patcher, can refer to [deploy-example](deploy-example
 
 Below is a table of available configurations:
 
-| Config name         | ENV                        | Command flag         | Default value       | Description                                                                                  |
-| ------------------- | -------------------------- | -------------------- | ------------------- | -------------------------------------------------------------------------------------------- |
-| force               | CONFIG_FORCE               | -force               | true                | overwrite secrets when not match                                                             |
-| debug               | CONFIG_DEBUG               | -debug               | false               | show DEBUG logs                                                                              |
-| serviceaccounts     | CONFIG_SERVICEACCOUNTS     | -serviceaccounts     | "default"           | comma-separated list of serviceaccounts to patch                                             |
-| all service account | CONFIG_ALLSERVICEACCOUNT   | -allserviceaccount   | false               | if true, list and patch all service accounts and the `-servicesaccounts` argument is ignored |
-| dockerconfigjson    | CONFIG_DOCKERCONFIGJSON    | -dockerconfigjson    | ""                  | json credential for authenicating container registry                                         |
-| secret name         | CONFIG_SECRETNAME          | -secretname          | "image-pull-secret" | name of managed secrets                                                                      |
-| excluded namespaces | CONFIG_EXCLUDED_NAMESPACES | -excluded-namespaces | ""                  | comma-separated namespaces excluded from processing                                          |
+| Config name         | ENV                        | Command flag         | Default value       | Description                                                                                                                       |
+| ------------------- | -------------------------- | -------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| force               | CONFIG_FORCE               | -force               | true                | overwrite secrets when not match                                                                                                  |
+| debug               | CONFIG_DEBUG               | -debug               | false               | show DEBUG logs                                                                                                                   |
+| serviceaccounts     | CONFIG_SERVICEACCOUNTS     | -serviceaccounts     | "default"           | comma-separated list of serviceaccounts to patch                                                                                  |
+| all service account | CONFIG_ALLSERVICEACCOUNT   | -allserviceaccount   | false               | if true, list and patch all service accounts and the `-servicesaccounts` argument is ignored                                      |
+| dockerconfigjson    | CONFIG_DOCKERCONFIGJSON    | -dockerconfigjson    | ""                  | json credential for authenicating container registry                                                                              |
+| secret name         | CONFIG_SECRETNAME          | -secretname          | "image-pull-secret" | name of managed secrets                                                                                                           |
+| excluded namespaces | CONFIG_EXCLUDED_NAMESPACES | -excluded-namespaces | ""                  | comma-separated namespaces excluded from processing                                                                               |
+| loop duration       | CONFIG_LOOP_DURATION       | -loop-duration       | 10 seconds          | duration string which defines how often namespaces are checked, see https://golang.org/pkg/time/#ParseDuration for more examples  |
 
 And here are the annotations available:
 

--- a/config_helper.go
+++ b/config_helper.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"strconv"
+	"time"
 )
 
 // Reference:
@@ -42,5 +43,21 @@ func LookUpEnvOrBool(key string, defaultVal bool) bool {
 	if err != nil {
 		return defaultVal
 	}
+	return val
+}
+
+// LookupEnvOrDuration lookup ENV string with given key and convert to time.Duration
+// or returns default value if not exists
+func LookupEnvOrDuration(key string, defaultVal time.Duration) time.Duration {
+	str, ok := os.LookupEnv(key)
+	if !ok {
+		return defaultVal
+	}
+
+	val, err :=time.ParseDuration(str)
+	if err != nil {
+		return defaultVal
+	}
+
 	return val
 }

--- a/config_helper_test.go
+++ b/config_helper_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"testing"
+	"time"
 )
 
 var testCasesLookupEnvOrString = []struct {
@@ -130,6 +131,52 @@ func TestLookupEnvOrBool(t *testing.T) {
 		actual := LookUpEnvOrBool(testCase.lookupKey, testCase.defaultVal)
 		if actual != testCase.expected {
 			t.Errorf("LookupEnvOrBool(%s) gives %v, expects %v", testCase.name, actual, testCase.expected)
+		}
+	}
+}
+
+var testCasesLookupEnvOrDuration = []struct {
+	name       string
+	envs       map[string]string
+	defaultVal time.Duration
+	lookupKey  string
+	expected   time.Duration
+}{
+	{
+		name: "hit",
+		envs: map[string]string{
+			"TEST": "30s",
+		},
+		lookupKey:  "TEST",
+		defaultVal: 10 * time.Second,
+		expected:   30 * time.Second,
+	},
+	{
+		name: "miss",
+		envs: map[string]string{
+			"MISS": "30s",
+		},
+		lookupKey:  "TEST",
+		defaultVal: 10 * time.Second,
+		expected:   10 * time.Second,
+	},
+	{
+		name: "not a time duration",
+		envs: map[string]string{
+			"TEST": "no duration string",
+		},
+		lookupKey:  "TEST",
+		defaultVal: 10 * time.Second,
+		expected:   10 * time.Second,
+	},
+}
+
+func TestLookupEnvOrDuration(t *testing.T) {
+	for _, testCase := range testCasesLookupEnvOrDuration {
+		prepareEnvs(testCase.envs)
+		actual := LookupEnvOrDuration(testCase.lookupKey, testCase.defaultVal)
+		if actual != testCase.expected {
+			t.Errorf("LookupEnvOrDuration(%s) gives %v, expects %v", testCase.name, actual, testCase.expected)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ var (
 	configSecretName         string = "image-pull-secret" // default to image-pull-secret
 	configExcludedNamespaces string = ""
 	configServiceAccounts    string = defaultServiceAccountName
+	configLoopDuration       time.Duration =  10 * time.Second
 )
 
 const (
@@ -42,6 +43,7 @@ func main() {
 	flag.StringVar(&configSecretName, "secretname", LookupEnvOrString("CONFIG_SECRETNAME", configSecretName), "set name of managed secrets")
 	flag.StringVar(&configExcludedNamespaces, "excluded-namespaces", LookupEnvOrString("CONFIG_EXCLUDED_NAMESPACES", configExcludedNamespaces), "comma-separated namespaces excluded from processing")
 	flag.StringVar(&configServiceAccounts, "serviceaccounts", LookupEnvOrString("CONFIG_SERVICEACCOUNTS", configServiceAccounts), "comma-separated list of serviceaccounts to patch")
+	flag.DurationVar(&configLoopDuration, "loop-duration", LookupEnvOrDuration("CONFIG_LOOP_DURATION", configLoopDuration), "String defining the loop duration")
 	flag.Parse()
 
 	// setup logrus
@@ -66,7 +68,7 @@ func main() {
 	for {
 		log.Debug("Loop started")
 		loop(k8s)
-		time.Sleep(10 * time.Second)
+		time.Sleep(configLoopDuration)
 	}
 }
 


### PR DESCRIPTION
Introduces a configuration option to tweak the duration of the loop time
instead of hard coding it to 10s. The default is still 10s but now we
have the option to tweak the time.