### PR TITLE
[RBAC] Restricting permissions

### DIFF
--- a/deploy-example/kubernetes-manifest/1_rbac.yaml
+++ b/deploy-example/kubernetes-manifest/1_rbac.yaml
@@ -5,13 +5,39 @@ metadata:
   namespace: imagepullsecret-patcher
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: image-pull-secret-patcher
+  name: image-pull-secret-patcher
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - serviceaccounts
+  verbs:
+  - list
+  - patch
+  - create
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: imagepullsecret-patcher
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: image-pull-secret-patcher
 subjects:
   - kind: ServiceAccount
     name: imagepullsecret-patcher

--- a/deploy-example/kubernetes-manifest/1_rbac.yaml
+++ b/deploy-example/kubernetes-manifest/1_rbac.yaml
@@ -8,8 +8,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    k8s-app: image-pull-secret-patcher
-  name: image-pull-secret-patcher
+    k8s-app: imagepullsecret-patcher
+  name: imagepullsecret-patcher
 rules:
 - apiGroups:
   - ""
@@ -37,7 +37,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: image-pull-secret-patcher
+  name: imagepullsecret-patcher
 subjects:
   - kind: ServiceAccount
     name: imagepullsecret-patcher


### PR DESCRIPTION
Currently the example binds cluster-admin Cluster role to the service account, which is not something that is required. This PR gives the restricted permissions that is required for the app to function. 

