### PR TITLE
Prevent modification of a secret unless it is annotated as managed by this application

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Below is a table of available configurations:
 | ------------------- | -------------------------- | -------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | force               | CONFIG_FORCE               | -force               | true                | overwrite secrets when not match                                                                                                  |
 | debug               | CONFIG_DEBUG               | -debug               | false               | show DEBUG logs                                                                                                                   |
+| managedonly         | CONFIG_MANAGEDONLY         | -managedonly         | false               | only modify secrets which were created by imagepullsecret                                                                         |
 | serviceaccounts     | CONFIG_SERVICEACCOUNTS     | -serviceaccounts     | "default"           | comma-separated list of serviceaccounts to patch                                                                                  |
 | all service account | CONFIG_ALLSERVICEACCOUNT   | -allserviceaccount   | false               | if true, list and patch all service accounts and the `-servicesaccounts` argument is ignored                                      |
 | dockerconfigjson    | CONFIG_DOCKERCONFIGJSON    | -dockerconfigjson    | ""                  | json credential for authenicating container registry                                                                              |
@@ -33,7 +34,7 @@ And here are the annotations available:
 
 | Annotation                                        | Object    | Description                                                                                                       |
 | ------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
-| k8s.titansoft.com/imagepullsecret-patcher-exclude | namespace | If a namespace is set this annoation with "true", it will be excluded from processing by imagepullsecret-patcher. |
+| k8s.titansoft.com/imagepullsecret-patcher-exclude | namespace | If a namespace is set this annotation with "true", it will be excluded from processing by imagepullsecret-patcher. |
 
 ## Why
 

--- a/config_helper.go
+++ b/config_helper.go
@@ -54,7 +54,7 @@ func LookupEnvOrDuration(key string, defaultVal time.Duration) time.Duration {
 		return defaultVal
 	}
 
-	val, err :=time.ParseDuration(str)
+	val, err := time.ParseDuration(str)
 	if err != nil {
 		return defaultVal
 	}

--- a/secret.go
+++ b/secret.go
@@ -5,13 +5,27 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type verifySecretResult string
+
+const (
+	// annotation constants
+	annotationManagedBy = "app.kubernetes.io/managed-by"
+	annotationAppName   = "imagepullsecret-patcher"
+
+	// result code for verifySecret
+	secretOk           verifySecretResult = "SecretOk"
+	secretWrongType    verifySecretResult = "SecretWrongType"
+	secretNoKey        verifySecretResult = "SecretNoKey"
+	secretDataNotMatch verifySecretResult = "SecretDataNotMatch"
+)
+
 func dockerconfigSecret(namespace string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      configSecretName,
 			Namespace: namespace,
 			Annotations: map[string]string{
-				"app.kubernetes.io/managed-by": "imagepullsecret-patcher",
+				annotationManagedBy: annotationAppName,
 			},
 		},
 		Data: map[string][]byte{
@@ -20,16 +34,6 @@ func dockerconfigSecret(namespace string) *corev1.Secret {
 		Type: corev1.SecretTypeDockerConfigJson,
 	}
 }
-
-type verifySecretResult string
-
-const (
-	// result code for verifySecret
-	secretOk           verifySecretResult = "SecretOk"
-	secretWrongType    verifySecretResult = "SecretWrongType"
-	secretNoKey        verifySecretResult = "SecretNoKey"
-	secretDataNotMatch verifySecretResult = "SecretDataNotMatch"
-)
 
 func verifySecret(secret *corev1.Secret) verifySecretResult {
 	if secret.Type != corev1.SecretTypeDockerConfigJson {
@@ -43,4 +47,13 @@ func verifySecret(secret *corev1.Secret) verifySecretResult {
 		return secretDataNotMatch
 	}
 	return secretOk
+}
+
+func isManagedSecret(secret *corev1.Secret) bool {
+	if k, ok := secret.ObjectMeta.Annotations[annotationManagedBy]; ok {
+		if k == annotationAppName {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
It was surprising to me when I spun this up that it overwrite the secret I had intended it to distribute, as I hadn't understood the intent of the program initially, i.e. to take an explicit static credential and to propagate it.  I believe this change can provide some additional security around accidentally overwriting a secret as I experienced. 