### PR TITLE
Support reading secrets dynamically from a volume mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,30 @@ To install imagepullsecret-patcher, can refer to [deploy-example](deploy-example
 
 Below is a table of available configurations:
 
-| Config name         | ENV                        | Command flag         | Default value       | Description                                                                                                                       |
-| ------------------- | -------------------------- | -------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| force               | CONFIG_FORCE               | -force               | true                | overwrite secrets when not match                                                                                                  |
-| debug               | CONFIG_DEBUG               | -debug               | false               | show DEBUG logs                                                                                                                   |
-| managedonly         | CONFIG_MANAGEDONLY         | -managedonly         | false               | only modify secrets which were created by imagepullsecret                                                                         |
-| serviceaccounts     | CONFIG_SERVICEACCOUNTS     | -serviceaccounts     | "default"           | comma-separated list of serviceaccounts to patch                                                                                  |
-| all service account | CONFIG_ALLSERVICEACCOUNT   | -allserviceaccount   | false               | if true, list and patch all service accounts and the `-servicesaccounts` argument is ignored                                      |
-| dockerconfigjson    | CONFIG_DOCKERCONFIGJSON    | -dockerconfigjson    | ""                  | json credential for authenicating container registry                                                                              |
-| secret name         | CONFIG_SECRETNAME          | -secretname          | "image-pull-secret" | name of managed secrets                                                                                                           |
-| excluded namespaces | CONFIG_EXCLUDED_NAMESPACES | -excluded-namespaces | ""                  | comma-separated namespaces excluded from processing                                                                               |
-| loop duration       | CONFIG_LOOP_DURATION       | -loop-duration       | 10 seconds          | duration string which defines how often namespaces are checked, see https://golang.org/pkg/time/#ParseDuration for more examples  |
+| Config name          | ENV                         | Command flag          | Default value       | Description                                                                                                                      |
+| -------------------- | --------------------------- | --------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| force                | CONFIG_FORCE                | -force                | true                | overwrite secrets when not match                                                                                                 |
+| debug                | CONFIG_DEBUG                | -debug                | false               | show DEBUG logs                                                                                                                  |
+| managedonly          | CONFIG_MANAGEDONLY          | -managedonly          | false               | only modify secrets which were created by imagepullsecret                                                                         |
+| serviceaccounts      | CONFIG_SERVICEACCOUNTS      | -serviceaccounts      | "default"           | comma-separated list of serviceaccounts to patch                                                                                 |
+| all service account  | CONFIG_ALLSERVICEACCOUNT    | -allserviceaccount    | false               | if true, list and patch all service accounts and the `-servicesaccounts` argument is ignored                                     |
+| dockerconfigjson     | CONFIG_DOCKERCONFIGJSON     | -dockerconfigjson     | ""                  | json credential for authenicating container registry                                                                             |
+| dockerconfigjsonpath | CONFIG_DOCKERCONFIGJSONPATH | -dockerconfigjsonpath | ""                  | path for of mounted json credentials for dynamic secret management                                                               |
+| secret name          | CONFIG_SECRETNAME           | -secretname           | "image-pull-secret" | name of managed secrets                                                                                                          |
+| excluded namespaces  | CONFIG_EXCLUDED_NAMESPACES  | -excluded-namespaces  | ""                  | comma-separated namespaces excluded from processing                                                                              |
+| loop duration        | CONFIG_LOOP_DURATION        | -loop-duration        | 10 seconds          | duration string which defines how often namespaces are checked, see https://golang.org/pkg/time/#ParseDuration for more examples |
 
 And here are the annotations available:
 
 | Annotation                                        | Object    | Description                                                                                                       |
 | ------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
 | k8s.titansoft.com/imagepullsecret-patcher-exclude | namespace | If a namespace is set this annotation with "true", it will be excluded from processing by imagepullsecret-patcher. |
+
+## Providing credentials
+
+You can provide the authentication credentials for imagepullsecret to populate across namespaces in a couple of ways.
+
+You can provide a raw secret as an environment variable, or better yet, by mounting a volume into the container. Mounted secrets can be dynamically updated and are more secure. Please see the relevant docs for more information https://kubernetes.io/docs/concepts/configuration/secret/
 
 ## Why
 

--- a/deploy-example/kubernetes-manifest/2_deployment.yaml
+++ b/deploy-example/kubernetes-manifest/2_deployment.yaml
@@ -36,11 +36,12 @@ spec:
               value: "false"
             - name: CONFIG_ALLSERVICEACCOUNT
               value: "true"
-            - name: CONFIG_DOCKERCONFIGJSON
-              valueFrom:
-                secretKeyRef:
-                  name: image-pull-secret
-                  key: .dockerconfigjson
+            - name: CONFIG_DOCKERCONFIGJSONPATH
+              value: "/app/secrets/.dockerconfigjson"
+          volumeMounts:
+            - name: src_dockerconfigjson
+              mountPath: "/app/secrets"
+              readOnly: true
           resources:
             requests:
               cpu: 0.1
@@ -48,3 +49,6 @@ spec:
             limits:
               cpu: 0.2
               memory: 30Mi
+      volumes:
+        - name: src_dockerconfigjson
+          secret: image-pull-secret

--- a/main.go
+++ b/main.go
@@ -59,8 +59,8 @@ func main() {
 	}
 	log.Info("Application started")
 
-	// Validate input, as both of these being configured would be surprising.
-	if configDockerconfigjson == "" && configDockerConfigJSONPath == "" {
+	// Validate input, as both of these being configured would have undefined behavior.
+	if configDockerconfigjson != "" && configDockerConfigJSONPath != "" {
 		log.Panic(fmt.Errorf("Cannot specify both `configdockerjson` and `configdockerjsonpath`"))
 	}
 

--- a/main.go
+++ b/main.go
@@ -16,15 +16,19 @@ import (
 )
 
 var (
-	configForce              bool          = true
-	configDebug              bool          = false
-	configManagedOnly        bool          = false
-	configAllServiceAccount  bool          = false
-	configDockerconfigjson   string        = ""
-	configSecretName         string        = "image-pull-secret" // default to image-pull-secret
-	configExcludedNamespaces string        = ""
-	configServiceAccounts    string        = defaultServiceAccountName
-	configLoopDuration       time.Duration = 10 * time.Second
+	// Config
+	configForce                bool          = true
+	configDebug                bool          = false
+	configManagedOnly          bool          = false
+	configAllServiceAccount    bool          = false
+	configDockerconfigjson     string        = ""
+	configDockerConfigJSONPath string        = ""
+	configSecretName           string        = "image-pull-secret" // default to image-pull-secret
+	configExcludedNamespaces   string        = ""
+	configServiceAccounts      string        = defaultServiceAccountName
+	configLoopDuration         time.Duration = 10 * time.Second
+
+	dockerConfigJSON string
 )
 
 const (
@@ -41,7 +45,8 @@ func main() {
 	flag.BoolVar(&configManagedOnly, "managedonly", LookUpEnvOrBool("CONFIG_MANAGEDONLY", configManagedOnly), "only modify secrets which are annotated as managed by imagepullsecret")
 	flag.BoolVar(&configDebug, "debug", LookUpEnvOrBool("CONFIG_DEBUG", configDebug), "show DEBUG logs")
 	flag.BoolVar(&configAllServiceAccount, "allserviceaccount", LookUpEnvOrBool("CONFIG_ALLSERVICEACCOUNT", configAllServiceAccount), "if false, patch just default service account; if true, list and patch all service accounts")
-	flag.StringVar(&configDockerconfigjson, "dockerconfigjson", LookupEnvOrString("CONFIG_DOCKERCONFIGJSON", configDockerconfigjson), "json credential for authenicating container registry")
+	flag.StringVar(&configDockerconfigjson, "dockerconfigjson", LookupEnvOrString("CONFIG_DOCKERCONFIGJSON", configDockerconfigjson), "json credential for authenicating container registry, exclusive with `dockerconfigjsonpath`")
+	flag.StringVar(&configDockerConfigJSONPath, "dockerconfigjsonpath", LookupEnvOrString("CONFIG_DOCKERCONFIGJSONPATH", configDockerConfigJSONPath), "path to json file containing credentials for the registry to be distributed, exclusive with `dockerconfigjson`")
 	flag.StringVar(&configSecretName, "secretname", LookupEnvOrString("CONFIG_SECRETNAME", configSecretName), "set name of managed secrets")
 	flag.StringVar(&configExcludedNamespaces, "excluded-namespaces", LookupEnvOrString("CONFIG_EXCLUDED_NAMESPACES", configExcludedNamespaces), "comma-separated namespaces excluded from processing")
 	flag.StringVar(&configServiceAccounts, "serviceaccounts", LookupEnvOrString("CONFIG_SERVICEACCOUNTS", configServiceAccounts), "comma-separated list of serviceaccounts to patch")
@@ -53,6 +58,11 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 	log.Info("Application started")
+
+	// Validate input, as both of these being configured would be surprising.
+	if configDockerconfigjson == "" && configDockerConfigJSONPath == "" {
+		log.Panic(fmt.Errorf("Cannot specify both `configdockerjson` and `configdockerjsonpath`"))
+	}
 
 	// create k8s clientset from in-cluster config
 	config, err := rest.InClusterConfig()
@@ -75,6 +85,14 @@ func main() {
 }
 
 func loop(k8s *k8sClient) {
+	var err error
+
+	// Populate secret value to set
+	dockerConfigJSON, err = getDockerConfigJSON()
+	if err != nil {
+		log.Panic(err)
+	}
+
 	// get all namespaces
 	namespaces, err := k8s.clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
 	if err != nil {

--- a/secret.go
+++ b/secret.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"io/ioutil"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,6 +21,17 @@ const (
 	secretDataNotMatch verifySecretResult = "SecretDataNotMatch"
 )
 
+// getDockerConfigJSON is a dynamic getter for our secret value. It lets us
+// dynamically fetch the value from file or return the hard coded value,
+// providing a consistent interface for access
+func getDockerConfigJSON() (string, error) {
+	if configDockerConfigJSONPath != "" {
+		b, ok := ioutil.ReadFile(configDockerConfigJSONPath)
+		return string(b), ok
+	}
+	return configDockerconfigjson, nil
+}
+
 func dockerconfigSecret(namespace string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
@@ -29,7 +42,7 @@ func dockerconfigSecret(namespace string) *corev1.Secret {
 			},
 		},
 		Data: map[string][]byte{
-			corev1.DockerConfigJsonKey: []byte(configDockerconfigjson),
+			corev1.DockerConfigJsonKey: []byte(dockerConfigJSON),
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 	}
@@ -43,7 +56,7 @@ func verifySecret(secret *corev1.Secret) verifySecretResult {
 	if !ok {
 		return secretNoKey
 	}
-	if string(b) != configDockerconfigjson {
+	if string(b) != dockerConfigJSON {
 		return secretDataNotMatch
 	}
 	return secretOk

--- a/secret_test.go
+++ b/secret_test.go
@@ -59,7 +59,7 @@ var testCasesVerifySecret = []struct {
 }
 
 func TestVerifySecret(t *testing.T) {
-	configDockerconfigjson = testDockerconfig
+	dockerConfigJSON = testDockerconfig
 	for _, testCase := range testCasesVerifySecret {
 		actual := verifySecret(testCase.input)
 		if actual != testCase.expected {


### PR DESCRIPTION
This PR introduces the ability to distribute dynamic auth credentials by this utility as well as adopt a stronger security model for secret management.  This is possible by enabling the auth credentials to be read from a volume mount instead of through static environment variables.

This makes this utility a better fit for propagating short lived access credentials to a private registry, as those would presumably be modified more often than the pod is restarted. 