### PR TITLE
fix: different names for imagepullsecret

### DIFF
--- a/deploy-example/README.md
+++ b/deploy-example/README.md
@@ -1,4 +1,4 @@
-## deploy-example
+# deploy-example
 
 Here is an example deployment to a kubernetes cluster.
 
@@ -6,8 +6,8 @@ Remember to change the Secret is specified in [2_deployment.yaml](kubernetes-man
 
 To manually create such secret can follow https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line.
 
-```
-kubectl create secret docker-registry image-pull-secret \
+```shell
+kubectl create secret docker-registry image-pull-secret-src \
   -n imagepullsecret-patcher \
   --docker-server=<your-registry-server> \
   --docker-username=<your-name> \

--- a/deploy-example/kubernetes-manifest/2_deployment.yaml
+++ b/deploy-example/kubernetes-manifest/2_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
-  name: image-pull-secret
+  name: image-pull-secret-src
   namespace: imagepullsecret-patcher
 data:
   .dockerconfigjson: eyJhdXRocyI6eyJnY3IuaW8iOnsicGFzc3dvcmQiOiJ7XCJhdXRoXCI6e1wiZ2NyLmlvXCI6e1widXNlcm5hbWVcIjpcIl9qc29uX2tleVwiLFwicGFzc3dvcmRcIjpcInt9XCJ9fX0iLCJ1c2VybmFtZSI6Il9qc29uX2tleSJ9fX0=
@@ -52,4 +52,4 @@ spec:
       volumes:
         - name: src-dockerconfigjson
           secret: 
-            secretName: image-pull-secret
+            secretName: image-pull-secret-src


### PR DESCRIPTION
As discussed in issue #17 the names for the source secret to the destination secret need to be different.
This PR updates the example in the `deploy-examples` folder.