### PR TITLE
fix(vulnerabilities): update golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:1.13 as builder
+FROM golang:1.18.3 as builder
 
 ENV GO111MODULE=on
 


### PR DESCRIPTION
According to prisma cloud go version 1.13.15 has 24 vulnerabilities. An update solves the vulnerabilities.