### PR TITLE
fix: Explicitly Define Service Account Token in Pod Spec

### DIFF
--- a/deploy-example/kubernetes-manifest/1_rbac.yaml
+++ b/deploy-example/kubernetes-manifest/1_rbac.yaml
@@ -3,6 +3,8 @@ kind: ServiceAccount
 metadata:
   name: imagepullsecret-patcher
   namespace: imagepullsecret-patcher
+  annotations:
+    kubernetes.io/service-account.name: imagepullsecret-patcher-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy-example/kubernetes-manifest/2_deployment.yaml
+++ b/deploy-example/kubernetes-manifest/2_deployment.yaml
@@ -24,7 +24,6 @@ spec:
       labels:
         name: imagepullsecret-patcher
     spec:
-      automountServiceAccountToken: true
       serviceAccountName: imagepullsecret-patcher
       containers:
         - name: imagepullsecret-patcher
@@ -42,6 +41,9 @@ spec:
             - name: src-dockerconfigjson
               mountPath: "/app/secrets"
               readOnly: true
+            - name: sa-token
+              mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+              readOnly: true
           resources:
             requests:
               cpu: 0.1
@@ -51,5 +53,10 @@ spec:
               memory: 30Mi
       volumes:
         - name: src-dockerconfigjson
-          secret: 
+          secret:
             secretName: image-pull-secret-src
+        - name: sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token


### PR DESCRIPTION
### Summary
This PR explicitly defines the service account token in the Pod specification to resolve an issue where Pods were failing due to a missing ConfigMap.

### Related Issues
Fixes #31

### Motivation
This change became necessary due to a provider-specific behavior observed in Kubernetes v1.27 on Civo (k3s), where the current manifest initially worked but later stopped functioning. Explicitly defining the token makes it consistently available to the Pod.

### Technical Description
We modified the Pod specification to include an explicit reference to the service account token. This ensures that the Pod can access necessary resources, as outlined in issue #31.

### Testing
Deployed the modified manifest in a Kubernetes v1.27 environment and verified that the Pod can now successfully locate the ConfigMap. I used terraform syntax so somebody might confirm my raw yaml is correct.

### Additional Context
This modification aligns with emerging Kubernetes practices and appears to be the direction in which Kubernetes is heading. It's designed to be future-proof and to ensure the system remains robust against evolving provider-specific behaviors.